### PR TITLE
Api authorization

### DIFF
--- a/app-modules/User/Models/CommonUser.php
+++ b/app-modules/User/Models/CommonUser.php
@@ -2,6 +2,7 @@
 
 namespace AppModules\User\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class CommonUser extends User
@@ -18,4 +19,17 @@ class CommonUser extends User
     protected $visible = [
         'type'
     ];
+
+    protected $attributes = [
+        'type' => 'common_user',
+    ];
+
+    public static function booted(): void
+    {
+        parent::booted();
+
+        static::addGlobalScope('common', function (Builder $builder) {
+            $builder->where('type', 'common_user');
+        });
+    }
 }

--- a/app-modules/User/Models/MerchantUser.php
+++ b/app-modules/User/Models/MerchantUser.php
@@ -3,11 +3,14 @@
 namespace AppModules\User\Models;
 
 use AppModules\User\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class MerchantUser extends User
 {
     use HasFactory;
+
+    protected $table = 'users';
 
     protected $fillable = [
         'name',
@@ -15,4 +18,17 @@ class MerchantUser extends User
         'password',
         'cnpj',
     ];
+
+    protected $attributes = [
+        'type' => 'merchant_user',
+    ];
+
+    public static function booted(): void
+    {
+        parent::booted();
+
+        static::addGlobalScope('merchant', function (Builder $builder) {
+            $builder->where('type', 'merchant_user');
+        });
+    }
 }

--- a/app-modules/User/Services/AuthService.php
+++ b/app-modules/User/Services/AuthService.php
@@ -22,8 +22,12 @@ class AuthService
             return ['status' => 'error', 'message' => 'Unauthorized'];
         }
 
-        $token = $user->createToken('auth_token')->plainTextToken;
+        if ($user->type === 'common_user') {
+            $token = $user->createToken('auth_token', ['money-transfer'])->plainTextToken;
+        } else {
+            $token = $user->createToken('auth_token')->plainTextToken;
+        }
 
-        return ['status' => 'success', 'token' => $token];
+        return ['status' => 'success', 'token' => $token, 'type' => $user->type];
     }
 }

--- a/app-modules/Wallet/Exceptions/InsufficientFundsException.php
+++ b/app-modules/Wallet/Exceptions/InsufficientFundsException.php
@@ -1,0 +1,7 @@
+<?php
+namespace AppModules\Wallet\Exceptions;
+
+class InsufficientFundsException extends \Exception
+{
+    protected $message = 'Insufficient funds';
+}

--- a/app-modules/Wallet/Exceptions/UnauthorizedTransferException.php
+++ b/app-modules/Wallet/Exceptions/UnauthorizedTransferException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AppModules\Wallet\Exceptions;
+
+class UnauthorizedTransferException extends \Exception
+{
+    protected $message = 'Unauthorized transfer';
+}

--- a/app-modules/Wallet/Http/Controllers/TransactionController.php
+++ b/app-modules/Wallet/Http/Controllers/TransactionController.php
@@ -2,9 +2,9 @@
 
 namespace AppModules\Wallet\Http\Controllers;
 
-use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use AppModules\Wallet\Services\TransferService;
+use AppModules\Wallet\Http\Requests\TransferRequest;
 use AppModules\User\Database\Repositories\Eloquent\UserRepository;
 
 class TransactionController extends Controller
@@ -14,7 +14,7 @@ class TransactionController extends Controller
         protected UserRepository $userRepository
     ) {}
 
-    public function transfer(Request $request)
+    public function transfer(TransferRequest $request)
     {
         $validated = $request->validate([
             'sender_id' => 'required|exists:users,id',

--- a/app-modules/Wallet/Http/Controllers/TransactionController.php
+++ b/app-modules/Wallet/Http/Controllers/TransactionController.php
@@ -19,8 +19,8 @@ class TransactionController extends Controller
         try {
             $this->transferService->execute(
                 $request->sender_id,
-                $$request->receiver_id,
-                $$request->amount
+                $request->receiver_id,
+                $request->amount
             );
             return response()->json(['message' => 'Transferência realizada com sucesso.'], 200);
         } catch (InsufficientFundsException $e) {

--- a/app-modules/Wallet/Http/Requests/TransferRequest.php
+++ b/app-modules/Wallet/Http/Requests/TransferRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AppModules\Wallet\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class TransferRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules()
+    {
+        return [
+            'sender_id' => 'required|exists:users,id',
+            'receiver_id' => 'required|exists:users,id|different:sender_id',
+            'amount' => 'required|numeric|min:0.01',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'receiver_id.different' => 'O recebedor não pode ser o mesmo que o remetente.',
+        ];
+    }
+}

--- a/app-modules/Wallet/Http/Routes/V1/api.php
+++ b/app-modules/Wallet/Http/Routes/V1/api.php
@@ -6,4 +6,4 @@ namespace AppModules\Wallet\Http\Routes\V1;
 use Illuminate\Support\Facades\Route;
 use AppModules\Wallet\Http\Controllers\TransactionController;
 
-Route::post('/transfer', [TransactionController::class, 'transfer']);
+Route::post('/transfer', [TransactionController::class, 'transfer'])->middleware(['auth:sanctum', 'ability:money-transfer']);

--- a/app-modules/Wallet/Providers/WalletServiceProvider.php
+++ b/app-modules/Wallet/Providers/WalletServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace AppModules\Wallet\Providers;
 
+use AppModules\User\Models\User;
 use Illuminate\Support\ServiceProvider;
 use AppModules\Wallet\Services\TransferService;
 use AppModules\Wallet\Services\BalanceValidator;
@@ -10,6 +11,7 @@ use AppModules\Wallet\Repositories\Eloquent\WalletRepository;
 use AppModules\Wallet\Services\Interfaces\TransferServiceInterface;
 use AppModules\Wallet\Services\Interfaces\BalanceValidatorInterface;
 use AppModules\Wallet\Repositories\Interfaces\WalletRepositoryInterface;
+use AppModules\User\Database\Repositories\Interfaces\UserRepositoryInterface;
 use AppModules\Authorization\Services\Interfaces\AuthorizationServiceInterface;
 
 class WalletServiceProvider extends ServiceProvider
@@ -23,12 +25,7 @@ class WalletServiceProvider extends ServiceProvider
     {
         $this->app->bind(WalletRepositoryInterface::class, WalletRepository::class);
         $this->app->bind(BalanceValidatorInterface::class, BalanceValidator::class);
-        $this->app->singleton(TransferService::class, function ($app) {
-            return new TransferService(
-                $app->make(TransferStrategyFactory::class),
-                $app->make(AuthorizationServiceInterface::class)
-            );
-        });
+        
     }
 
     /**
@@ -39,5 +36,12 @@ class WalletServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->loadMigrationsFrom(__DIR__ . '/../Database/Migrations');
+        $this->app->bind(TransferService::class, function ($app) {
+            return new TransferService(
+                $app->make(TransferStrategyFactory::class),
+                $app->make(AuthorizationServiceInterface::class),
+                $app->make(UserRepositoryInterface::class)
+            );
+        });
     }
 }

--- a/app-modules/Wallet/Services/CommonToCommonTransferStrategy.php
+++ b/app-modules/Wallet/Services/CommonToCommonTransferStrategy.php
@@ -2,12 +2,11 @@
 
 namespace AppModules\Wallet\Services;
 
-use Exception;
-
 use AppModules\User\Models\User;
 use Illuminate\Support\Facades\DB;
 use AppModules\Wallet\Models\Wallet;
 use AppModules\Wallet\Models\Transaction;
+use AppModules\Wallet\Exceptions\InsufficientFundsException;
 use AppModules\Wallet\Services\Interfaces\TransferServiceInterface;
 use AppModules\Wallet\Services\Interfaces\BalanceValidatorInterface;
 use AppModules\Wallet\Repositories\Interfaces\WalletRepositoryInterface;
@@ -28,7 +27,7 @@ class CommonToCommonTransferStrategy implements TransferServiceInterface
             $receiverWallet = Wallet::where('user_id', $receiver->id)->lockForUpdate()->first();
 
             if (!$this->balanceValidator->validate($sender->id, $amount)) {
-                throw new Exception('Insufficient balance');
+                throw new InsufficientFundsException('Insufficient balance');
             }
 
             $this->walletRepository->decreaseBalance($sender->id, $amount);

--- a/app-modules/Wallet/Tests/Feature/TransferFeatureTest.php
+++ b/app-modules/Wallet/Tests/Feature/TransferFeatureTest.php
@@ -153,4 +153,18 @@ class TransferFeatureTest extends WalletTestCase
 
         $this->sut->execute($sender, $receiver, 50);
     }
+
+    public function test_transfer_fails_with_same_sender_and_receiver()
+    {
+        $user = User::factory()->create(['balance' => 100]);
+
+        $response = $this->postJson('/api/transfer', [
+            'sender_id' => $user->id,
+            'receiver_id' => $user->id,
+            'amount' => 50,
+        ]);
+
+        $response->assertStatus(422)
+                 ->assertJsonValidationErrors(['receiver_id']);
+    }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,8 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Laravel\Sanctum\Http\Middleware\CheckAbilities;
+use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -17,7 +19,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'abilities' => CheckAbilities::class,
+            'ability' => CheckForAnyAbility::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
O usuário autenticado pode transferir somente da própria carteira.
Usuário do tipo “common' vai receber um token com a autorização “money-transfer”.
Adicionar ability 'money-transfer' a api de tranferência